### PR TITLE
Add external IDs to support order-sync-svc

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -12,7 +12,7 @@ const (
 	ioBookingIDPrefix          = "io:booking:"
 	ioEmployeeeNumberPrefix    = "io:employee:"
 	ioOrderIDPrefix            = "io:order:"
-	ioOrderMarketIDPrefix      = "io:order:"
+	ioOrderMarketIDPrefix      = "io:orderMarket:"
 
 	quattroDbPrefix       = "quattro_:"
 	quattroCampaignPrefix = "campaign:"

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -12,6 +12,7 @@ const (
 	ioBookingIDPrefix          = "io:booking:"
 	ioEmployeeeNumberPrefix    = "io:employee:"
 	ioOrderIDPrefix            = "io:order:"
+	ioOrderNumberPrefix        = "io:orderNumber:"
 	ioOrderMarketIDPrefix      = "io:orderMarket:"
 
 	quattroDbPrefix       = "quattro_:"
@@ -31,6 +32,10 @@ func FormatGeopathTargetProfile(code interface{}) string {
 
 func FormatIOOrderID(orderID interface{}) string {
 	return format(ioOrderIDPrefix, fmt.Sprint(orderID))
+}
+
+func FormatIOOrderNumber(number interface{}) string {
+	return format(ioOrderNumberPrefix, fmt.Sprint(number))
 }
 
 func FormatIOBookingID(bookingID interface{}) string {

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -6,9 +6,28 @@ import (
 )
 
 const (
-	ioBookingIDPrefix = "io:booking:"
-	ioOrderIDPrefix   = "io:order:"
+	extAgencyCodePrefi         = "agency:code:"
+	geopathSegmentCodePrefix   = "geopath:segmentCode:"
+	geopathTargetProfilePrefix = "geopath:targetProfile:"
+	ioBookingIDPrefix          = "io:booking:"
+	ioEmployeeeNumberPrefix    = "io:employee:"
+	ioOrderIDPrefix            = "io:order:"
+	ioOrderMarketIDPrefix      = "io:order:"
+
+	quattroDbPrefix       = "quattro_:"
+	quattroCampaignPrefix = "campaign:"
 )
+
+func FormatExtAgencyCode(code interface{}) string {
+	return format(extAgencyCodePrefi, fmt.Sprint(code))
+}
+func FormatGeopathSegmentCode(code interface{}) string {
+	return format(geopathSegmentCodePrefix, fmt.Sprint(code))
+}
+
+func FormatGeopathTargetProfile(code interface{}) string {
+	return format(geopathTargetProfilePrefix, fmt.Sprint(code))
+}
 
 func FormatIOOrderID(orderID interface{}) string {
 	return format(ioOrderIDPrefix, fmt.Sprint(orderID))
@@ -16,6 +35,19 @@ func FormatIOOrderID(orderID interface{}) string {
 
 func FormatIOBookingID(bookingID interface{}) string {
 	return format(ioBookingIDPrefix, fmt.Sprint(bookingID))
+}
+
+func FormatIOEmployeeNumber(number interface{}) string {
+	return format(ioEmployeeeNumberPrefix, fmt.Sprint(number))
+}
+
+func FormatQuattroCampaign(marketCode string, campaignId interface{}) string {
+	key := formatQuattroKey(quattroCampaignPrefix, marketCode)
+	return format(key, fmt.Sprint(campaignId))
+}
+
+func formatQuattroKey(prefix string, marketCode string) string {
+	return format(quattroDbPrefix, marketCode)
 }
 
 func format(prefix string, identifier string) string {


### PR DESCRIPTION
New external ID support: 
- External agency code; `agency:code:xxxxx`
- geopath segment code; `geopath:segmentCode:xxxxx`
- geopath target profile; `geopath:targetProfile:xxxxx`
- io employee number; `io:employee:`
- io orderMarket ID; `io:orderMarket:`
- quattro campaign; `quattro_XXX:campaign:xxxxxx`
