### PR TITLE
Support booking-sync-svc

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -20,9 +20,10 @@ const (
 	ioOrderLineTypePrefix      = "io:orderLineType:"
 	ioOrderMarketIDPrefix      = "io:orderMarket:"
 
-	quattroDbPrefix       = "quattro_:"
-	quattroCampaignPrefix = "campaign:"
-	quattroPanelID        = ":display:"
+	quattroDbPrefix              = "quattro_"
+	quattroCampaignPrefix        = ":campaign:"
+	quattroCampaignSegmentPrefix = ":campaignSegment:"
+	quattroDisplayID             = ":display:"
 )
 
 func FormatIOAccount(id interface{}) string {
@@ -77,17 +78,21 @@ func FormatIOMarket(id interface{}) string {
 }
 
 func FormatQuattroCampaign(marketCode string, campaignId interface{}) string {
-	key := formatQuattroKey(quattroCampaignPrefix, marketCode)
-	return format(key, fmt.Sprint(campaignId))
+	return formatQuattroKey(marketCode, quattroCampaignPrefix, fmt.Sprint(campaignId))
 }
 
-func FormatQuattroPanelID(sourceDB string, panelID interface{}) string {
-	key := fmt.Sprintf("%s%s", sourceDB, quattroPanelID)
-	return format(key, fmt.Sprint(panelID))
+func FormatQuattroCampaignSegment(marketCode string, segmentId interface{}) string {
+	return formatQuattroKey(marketCode, quattroCampaignSegmentPrefix, fmt.Sprint(segmentId))
 }
 
-func formatQuattroKey(prefix string, marketCode string) string {
-	return format(quattroDbPrefix, marketCode)
+func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
+	return formatQuattroKey(sourceDbCode, quattroDisplayID, fmt.Sprint(panelID))
+}
+
+func formatQuattroKey(marketCode string, entity string, id string) string {
+	quattroKey := format(quattroDbPrefix, marketCode)
+	prefix := format(quattroKey, entity)
+	return format(prefix, id)
 }
 
 func format(prefix string, identifier string) string {

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -23,6 +23,7 @@ const (
 	quattroDbPrefix              = "quattro_"
 	quattroCampaignPrefix        = ":campaign:"
 	quattroCampaignSegmentPrefix = ":campaignSegment:"
+	quattroCampaignDetailPrefix  = ":campaignDetail:"
 	quattroDisplayID             = ":display:"
 )
 
@@ -83,6 +84,10 @@ func FormatQuattroCampaign(marketCode string, campaignId interface{}) string {
 
 func FormatQuattroCampaignSegment(marketCode string, segmentId interface{}) string {
 	return formatQuattroKey(marketCode, quattroCampaignSegmentPrefix, fmt.Sprint(segmentId))
+}
+
+func FormatQuattroDetailSegment(marketCode string, detailId interface{}) string {
+	return formatQuattroKey(marketCode, quattroCampaignDetailPrefix, fmt.Sprint(detailId))
 }
 
 func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -86,7 +86,7 @@ func FormatQuattroCampaignSegment(marketCode string, segmentId interface{}) stri
 	return formatQuattroKey(marketCode, quattroCampaignSegmentPrefix, fmt.Sprint(segmentId))
 }
 
-func FormatQuattroDetailSegment(marketCode string, detailId interface{}) string {
+func FormatQuattroCampaignDetail(marketCode string, detailId interface{}) string {
 	return formatQuattroKey(marketCode, quattroCampaignDetailPrefix, fmt.Sprint(detailId))
 }
 

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -1,0 +1,33 @@
+package externalIDs
+
+import "testing"
+
+func Test_FormatQuattroCampaign(t *testing.T) {
+	mar := "CHI"
+	id := "1234"
+
+	extId := FormatQuattroCampaign(mar, id)
+	if extId != "quattro_CHI:campaign:1234" {
+		t.Errorf("bad quattro campaign format; expected: %s; got: %s", "quattro_CHI:campaign:1234", extId)
+	}
+}
+
+func Test_FormatQuattroCampaignSegment(t *testing.T) {
+	mar := "CHI"
+	id := "1234"
+
+	segmentId := FormatQuattroCampaignSegment(mar, id)
+	if segmentId != "quattro_CHI:campaignSegment:1234" {
+		t.Errorf("bad quattro campaignSegment format; expected: %s; got: %s", "quattro_CHI:campaignSegment:1234", segmentId)
+	}
+}
+
+func Test_FormatQuattroDisplayID(t *testing.T) {
+	mar := "CHI"
+	id := "1234"
+
+	extId := FormatQuattroDisplayID(mar, id)
+	if extId != "quattro_CHI:display:1234" {
+		t.Errorf("bad quattro display format; expected: %s; got: %s", "quattro_CHI:display:1234", extId)
+	}
+}

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -22,6 +22,16 @@ func Test_FormatQuattroCampaignSegment(t *testing.T) {
 	}
 }
 
+func Test_FormatQuattroCampaignDetail(t *testing.T) {
+	mar := "CHI"
+	id := "1234"
+
+	detailId := FormatQuattroCampaignDetail(mar, id)
+	if detailId != "quattro_CHI:campaignDetail:1234" {
+		t.Errorf("bad quattro campaignSegment format; expected: %s; got: %s", "quattro_CHI:campaignDetail:1234", detailId)
+	}
+}
+
 func Test_FormatQuattroDisplayID(t *testing.T) {
 	mar := "CHI"
 	id := "1234"


### PR DESCRIPTION
- Add tests for quattro formatters 
- Add support for formatting Campaign Segment & Details 
- Rename FormatQuattroPanelID -> FormatQuattroDisplayID since it uses the `display` prefix 