### PR TITLE
feat: get ioapi legacy entity id from externalID

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -2,6 +2,7 @@ package externalIDs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -92,6 +93,36 @@ func FormatQuattroCampaignDetail(marketCode string, detailId interface{}) string
 
 func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
 	return formatQuattroKey(sourceDbCode, quattroDisplayID, fmt.Sprint(panelID))
+}
+
+func GetLegacyIOEntityNumericID(externalIDs []string, entity string) (*int, bool) {
+	for _, externalID := range externalIDs {
+		// if externalID does not begin with io:{entity} return nil,false
+		if !strings.HasPrefix(externalID, fmt.Sprintf("io:%s:", entity)) {
+			// skip this iteration
+			continue
+		}
+
+		//split the externalID into a 3-part array on the : character
+		externalIDParts := strings.Split(externalID, ":")
+		if len(externalIDParts) != 3 {
+			continue
+		}
+
+		// if entity part doesn't match requested type
+		if externalIDParts[1] != entity {
+			continue
+		}
+
+		// convert externalIDParts[2] to int
+		intID, err := strconv.Atoi(externalIDParts[2])
+		if err != nil {
+			continue
+		}
+
+		return &intID, true
+	}
+	return nil, false
 }
 
 func formatQuattroKey(marketCode string, entity string, id string) string {

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -95,7 +95,11 @@ func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
 	return formatQuattroKey(sourceDbCode, quattroDisplayID, fmt.Sprint(panelID))
 }
 
-func GetLegacyIOEntityNumericID(externalIDs []string, entity string) (*int, bool) {
+func GetLegacyIODisplayID(externalIDs []string) *int {
+	return getLegacyIOEntityNumericID(externalIDs, "display")
+}
+
+func getLegacyIOEntityNumericID(externalIDs []string, entity string) *int {
 	for _, externalID := range externalIDs {
 		// if externalID does not begin with io:{entity}
 		if !strings.HasPrefix(externalID, fmt.Sprintf("io:%s:", entity)) {
@@ -120,9 +124,9 @@ func GetLegacyIOEntityNumericID(externalIDs []string, entity string) (*int, bool
 			continue
 		}
 
-		return &intID, true
+		return &intID
 	}
-	return nil, false
+	return nil
 }
 
 func formatQuattroKey(marketCode string, entity string, id string) string {

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -97,7 +97,7 @@ func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
 
 func GetLegacyIOEntityNumericID(externalIDs []string, entity string) (*int, bool) {
 	for _, externalID := range externalIDs {
-		// if externalID does not begin with io:{entity} return nil,false
+		// if externalID does not begin with io:{entity}
 		if !strings.HasPrefix(externalID, fmt.Sprintf("io:%s:", entity)) {
 			// skip this iteration
 			continue

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -42,67 +42,49 @@ func Test_FormatQuattroDisplayID(t *testing.T) {
 	}
 }
 
-func Test_GetIOLegacyNumericEntityID(t *testing.T) {
+func Test_GetIOLegacyDisplayID(t *testing.T) {
 	extId := []string{"io:display:1234"}
-	id, ok := GetLegacyIOEntityNumericID(extId, "display")
-	if !ok {
-		t.Errorf("bad io display id format; expected: %s; got: %d", "1234", id)
-	}
+	id := GetLegacyIODisplayID(extId)
 	if *id != 1234 {
 		t.Errorf("bad io display id format; expected: %d; got: %d", 1234, *id)
 	}
 }
 
-func Test_GetIOLegacyNumericEntityID_NotRequestedEntity(t *testing.T) {
-	extId := []string{"io:display:1234"}
-	id, ok := GetLegacyIOEntityNumericID(extId, "campaign")
-	if ok {
-		t.Errorf("expected not ok %s : %d", "1234", id)
-	}
+func Test_GetIOLegacyDisplayID_NotRequestedEntity(t *testing.T) {
+	extId := []string{"io:campaign:1234"}
+	id := GetLegacyIODisplayID(extId)
 	if id != nil {
-		t.Errorf("expected nil got %d", id)
+		t.Errorf("expected nil got %d", &id)
 	}
 }
 
-func Test_GetIOLegacyNumericEntityID_NonConforming(t *testing.T) {
+func Test_GetIOLegacyDisplayID_NonConforming(t *testing.T) {
 	tooManyParts := []string{"io:display:1234:5678"}
-	id, ok := GetLegacyIOEntityNumericID(tooManyParts, "display")
-	if ok {
-		t.Errorf("too many parts expected not ok %s : %d", "1234", id)
-	}
+	id := GetLegacyIODisplayID(tooManyParts)
 	if id != nil {
 		t.Errorf("too many parts expected nil got %d", id)
 	}
 
 	tooFewParts := []string{"io:display"}
-	id, ok = GetLegacyIOEntityNumericID(tooFewParts, "display")
-	if ok {
-		t.Errorf("too few parts expected not ok %s : %d", "1234", id)
-	}
+	id = GetLegacyIODisplayID(tooFewParts)
 	if id != nil {
 		t.Errorf("too few parts expected nil got %d", id)
 	}
 }
 
 // only returns the first matching id
-func Test_GetIOLegacyNumericEntityID_MultipleIDs(t *testing.T) {
-	extId := []string{"io:market:1234", "io:display:1234", "io:display:5678"}
-	id, ok := GetLegacyIOEntityNumericID(extId, "display")
-	if !ok {
-		t.Errorf("expected ok %s : %d", "1234", id)
-	}
+func Test_GetIOLegacyDisplayID_MultipleIDs(t *testing.T) {
+	extIds := []string{"io:market:1234", "io:display:1234", "io:display:5678"}
+	id := GetLegacyIODisplayID(extIds)
 	if *id != 1234 {
 		t.Errorf("expected %d got %d", 1234, *id)
 	}
 }
 
 // test non-numeric id string
-func Test_GetIOLegacyNumericEntityID_NonNumericID(t *testing.T) {
-	extId := []string{"io:display:abc"}
-	id, ok := GetLegacyIOEntityNumericID(extId, "display")
-	if ok {
-		t.Errorf("expected not ok %s : %d", "abc", id)
-	}
+func Test_GetIOLegacyDisplayID_NonNumericID(t *testing.T) {
+	extIds := []string{"io:display:abc"}
+	id := GetLegacyIODisplayID(extIds)
 	if id != nil {
 		t.Errorf("expected nil got %d", id)
 	}

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -41,3 +41,69 @@ func Test_FormatQuattroDisplayID(t *testing.T) {
 		t.Errorf("bad quattro display format; expected: %s; got: %s", "quattro_CHI:display:1234", extId)
 	}
 }
+
+func Test_GetIOLegacyNumericEntityID(t *testing.T) {
+	extId := []string{"io:display:1234"}
+	id, ok := GetLegacyIOEntityNumericID(extId, "display")
+	if !ok {
+		t.Errorf("bad io display id format; expected: %s; got: %d", "1234", id)
+	}
+	if *id != 1234 {
+		t.Errorf("bad io display id format; expected: %d; got: %d", 1234, *id)
+	}
+}
+
+func Test_GetIOLegacyNumericEntityID_NotRequestedEntity(t *testing.T) {
+	extId := []string{"io:display:1234"}
+	id, ok := GetLegacyIOEntityNumericID(extId, "campaign")
+	if ok {
+		t.Errorf("expected not ok %s : %d", "1234", id)
+	}
+	if id != nil {
+		t.Errorf("expected nil got %d", id)
+	}
+}
+
+func Test_GetIOLegacyNumericEntityID_NonConforming(t *testing.T) {
+	tooManyParts := []string{"io:display:1234:5678"}
+	id, ok := GetLegacyIOEntityNumericID(tooManyParts, "display")
+	if ok {
+		t.Errorf("too many parts expected not ok %s : %d", "1234", id)
+	}
+	if id != nil {
+		t.Errorf("too many parts expected nil got %d", id)
+	}
+
+	tooFewParts := []string{"io:display"}
+	id, ok = GetLegacyIOEntityNumericID(tooFewParts, "display")
+	if ok {
+		t.Errorf("too few parts expected not ok %s : %d", "1234", id)
+	}
+	if id != nil {
+		t.Errorf("too few parts expected nil got %d", id)
+	}
+}
+
+// only returns the first matching id
+func Test_GetIOLegacyNumericEntityID_MultipleIDs(t *testing.T) {
+	extId := []string{"io:market:1234", "io:display:1234", "io:display:5678"}
+	id, ok := GetLegacyIOEntityNumericID(extId, "display")
+	if !ok {
+		t.Errorf("expected ok %s : %d", "1234", id)
+	}
+	if *id != 1234 {
+		t.Errorf("expected %d got %d", 1234, *id)
+	}
+}
+
+// test non-numeric id string
+func Test_GetIOLegacyNumericEntityID_NonNumericID(t *testing.T) {
+	extId := []string{"io:display:abc"}
+	id, ok := GetLegacyIOEntityNumericID(extId, "display")
+	if ok {
+		t.Errorf("expected not ok %s : %d", "abc", id)
+	}
+	if id != nil {
+		t.Errorf("expected nil got %d", id)
+	}
+}


### PR DESCRIPTION
New Behavior Introduced:

Adds a function that takes an ExternalIDs array and finds the first valid matching entity in the list and returns its numeric ID. Includes various validations (see tests)