### PR TITLE
Parse out site code

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -105,6 +105,10 @@ func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
 	return formatQuattroKey(sourceDbCode, quattroDisplayID, fmt.Sprint(panelID))
 }
 
+func GetLegacySiteCode(externalIDs []string) *int {
+	return getLegacyIOEntityNumericID(externalIDs, "site")
+}
+
 func GetLegacyIODisplayID(externalIDs []string) *int {
 	return getLegacyIOEntityNumericID(externalIDs, "display")
 }

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -109,3 +109,12 @@ func Test_GetIOLegacyDisplayID_NonNumericID(t *testing.T) {
 		t.Errorf("expected nil got %d", id)
 	}
 }
+
+// test getting site code
+func Test_GetLegacySiteCode(t *testing.T) {
+	extId := []string{"io:site:1234"}
+	id := GetLegacySiteCode(extId)
+	if *id != 1234 {
+		t.Errorf("bad site_code format; expected: %d; got: %d", 1234, *id)
+	}
+}


### PR DESCRIPTION
This introduces a way to parse out the `site_code` from the external ids block.