### PR TITLE
func to parse out quattro campaign ids from the externalIDs block

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -118,6 +118,11 @@ func GetQuattroBookingID(sourceDbCode string, externalIDs []string) *int {
 	return parseExternalID(prefix, externalIDs)
 }
 
+func GetQuattroCampaignID(marketCode string, externalIDs []string) *int {
+	prefix := formatQuattroKey(marketCode, quattroCampaignPrefix, "")
+	return parseExternalID(prefix, externalIDs)
+}
+
 func GetLegacySiteCode(externalIDs []string) *int {
 	return getLegacyIOEntityNumericID(externalIDs, "site")
 }

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -136,3 +136,11 @@ func Test_GetOrderNumber(t *testing.T) {
 		t.Errorf("expected 1234 got %d", *id)
 	}
 }
+
+func Test_GetQuattroCampaignID(t *testing.T) {
+	extIds := []string{"quattro_CHI:campaign:1234", "io:booking:2600", "io:display:5678"}
+	id := GetQuattroCampaignID("CHI", extIds)
+	if *id != 1234 {
+		t.Errorf("expected nil got %d", *id)
+	}
+}


### PR DESCRIPTION
This adds a function so that the quattro campaign id can be parsed out of the external IDS block