### PR TITLE
IDs should be returned as strings rather than ints

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -2,7 +2,6 @@ package externalIDs
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -110,53 +109,48 @@ func FormatQuattroNetworkID(sourceDbCode string, digitalProductID interface{}) s
 	return formatQuattroKey(sourceDbCode, quattroNetworkID, fmt.Sprint(digitalProductID))
 }
 
-func GetExtAgencyCode(externalIDs []string) *int {
+func GetExtAgencyCode(externalIDs []string) string {
 	return parseExternalID(extAgencyCodePrefix, externalIDs)
 }
 
-func GetOrderNumber(externalIDs []string) *int {
+func GetOrderNumber(externalIDs []string) string {
 	return parseExternalID(ioOrderNumberPrefix, externalIDs)
 }
 
-func GetEmployeeNumber(externalIDs []string) *int {
+func GetEmployeeNumber(externalIDs []string) string {
 	return parseExternalID(ioEmployeeeNumberPrefix, externalIDs)
 }
 
-func GetQuattroBookingID(sourceDbCode string, externalIDs []string) *int {
+func GetQuattroBookingID(sourceDbCode string, externalIDs []string) string {
 	prefix := formatQuattroKey(sourceDbCode, quattroBookingPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroCampaignID(marketCode string, externalIDs []string) *int {
+func GetQuattroCampaignID(marketCode string, externalIDs []string) string {
 	prefix := formatQuattroKey(marketCode, quattroCampaignPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetLegacySiteCode(externalIDs []string) *int {
+func GetLegacySiteCode(externalIDs []string) string {
 	return getLegacyIOEntityNumericID(externalIDs, "site")
 }
 
-func GetLegacyIODisplayID(externalIDs []string) *int {
+func GetLegacyIODisplayID(externalIDs []string) string {
 	return getLegacyIOEntityNumericID(externalIDs, "display")
 }
 
-func getLegacyIOEntityNumericID(externalIDs []string, entity string) *int {
+func getLegacyIOEntityNumericID(externalIDs []string, entity string) string {
 	prefix := fmt.Sprintf("io:%s:", entity)
 	return parseExternalID(prefix, externalIDs)
 }
 
-func parseExternalID(prefix string, externalIDs []string) *int {
+func parseExternalID(prefix string, externalIDs []string) string {
 	for _, externalID := range externalIDs {
 		if strings.HasPrefix(externalID, prefix) {
-			identifier := strings.TrimPrefix(externalID, prefix)
-			intID, err := strconv.Atoi(identifier)
-			if err != nil {
-				return nil
-			}
-			return &intID
+			return strings.TrimPrefix(externalID, prefix)
 		}
 	}
-	return nil
+	return ""
 }
 
 func formatQuattroKey(marketCode string, entity string, id string) string {

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -75,16 +75,16 @@ func Test_FormatQuattroDigitalBookingID(t *testing.T) {
 func Test_GetIOLegacyDisplayID(t *testing.T) {
 	extId := []string{"io:display:1234"}
 	id := GetLegacyIODisplayID(extId)
-	if *id != 1234 {
-		t.Errorf("bad io display id format; expected: %d; got: %d", 1234, *id)
+	if id != "1234" {
+		t.Errorf("bad io display id format; expected: %d; got: %s", 1234, id)
 	}
 }
 
 func Test_GetIOLegacyDisplayID_NotRequestedEntity(t *testing.T) {
 	extId := []string{"io:campaign:1234"}
 	id := GetLegacyIODisplayID(extId)
-	if id != nil {
-		t.Errorf("expected nil got %d", &id)
+	if id != "" {
+		t.Errorf("expected nil got %s", id)
 	}
 }
 
@@ -92,17 +92,8 @@ func Test_GetIOLegacyDisplayID_NotRequestedEntity(t *testing.T) {
 func Test_GetIOLegacyDisplayID_MultipleIDs(t *testing.T) {
 	extIds := []string{"io:market:1234", "io:display:1234", "io:display:5678"}
 	id := GetLegacyIODisplayID(extIds)
-	if *id != 1234 {
-		t.Errorf("expected %d got %d", 1234, *id)
-	}
-}
-
-// test non-numeric id string
-func Test_GetIOLegacyDisplayID_NonNumericID(t *testing.T) {
-	extIds := []string{"io:display:abc"}
-	id := GetLegacyIODisplayID(extIds)
-	if id != nil {
-		t.Errorf("expected nil got %d", id)
+	if id != "1234" {
+		t.Errorf("expected %d got %s", 1234, id)
 	}
 }
 
@@ -110,55 +101,55 @@ func Test_GetIOLegacyDisplayID_NonNumericID(t *testing.T) {
 func Test_GetLegacySiteCode(t *testing.T) {
 	extId := []string{"io:site:1234"}
 	id := GetLegacySiteCode(extId)
-	if *id != 1234 {
-		t.Errorf("bad site_code format; expected: %d; got: %d", 1234, *id)
+	if id != "1234" {
+		t.Errorf("bad site_code format; expected: %d; got: %s", 1234, id)
 	}
 }
 
 func Test_GetQuattroBookingID(t *testing.T) {
 	extIds := []string{"io:market:1234", "quattro_CHI:booking:2600", "io:display:5678"}
 	id := GetQuattroBookingID("CHI", extIds)
-	if *id != 2600 {
-		t.Errorf("expected %d got %d", 2600, *id)
+	if id != "2600" {
+		t.Errorf("expected %d got %s", 2600, id)
 	}
 }
 
 func Test_GetQuattroBookingID_NoBookingID(t *testing.T) {
 	extIds := []string{"io:market:1234", "io:booking:2600", "io:display:5678"}
 	id := GetQuattroBookingID("CHI", extIds)
-	if id != nil {
-		t.Errorf("expected nil got %d", *id)
+	if id != "" {
+		t.Errorf("expected nil got %s", id)
 	}
 }
 
 func Test_GetEmployeeNumber(t *testing.T) {
 	extIds := []string{"io:employeeNumber:1234", "io:booking:2600", "io:display:5678"}
 	id := GetEmployeeNumber(extIds)
-	if *id != 1234 {
-		t.Errorf("expected 1234 got %d", *id)
+	if id != "1234" {
+		t.Errorf("expected 1234 got %s", id)
 	}
 }
 
 func Test_GetOrderNumber(t *testing.T) {
 	extIds := []string{"io:orderNumber:1234", "io:booking:2600", "io:display:5678"}
 	id := GetOrderNumber(extIds)
-	if *id != 1234 {
-		t.Errorf("expected 1234 got %d", *id)
+	if id != "1234" {
+		t.Errorf("expected 1234 got %s", id)
 	}
 }
 
 func Test_GetQuattroCampaignID(t *testing.T) {
 	extIds := []string{"quattro_CHI:campaign:1234", "io:booking:2600", "io:display:5678"}
 	id := GetQuattroCampaignID("CHI", extIds)
-	if *id != 1234 {
-		t.Errorf("expected 1234 got %d", *id)
+	if id != "1234" {
+		t.Errorf("expected 1234 got %s", id)
 	}
 }
 
 func Test_GetExtAgencyCode(t *testing.T) {
 	extIds := []string{"agency:code:1234", "io:booking:2600", "io:display:5678"}
 	id := GetExtAgencyCode(extIds)
-	if *id != 1234 {
-		t.Errorf("expected 1234 got %d", *id)
+	if id != "1234" {
+		t.Errorf("expected 1234 got %s", id)
 	}
 }


### PR DESCRIPTION
Not every legacy identifier in the externalIDs block parses out to an int...`orderNumber` in particular can contain strings. This change makes it such that IDs are treated as strings, and return empty strings when one isn't found.