### PR TITLE
extract campaign segment ID

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -131,6 +131,11 @@ func GetQuattroCampaignID(marketCode string, externalIDs []string) string {
 	return parseExternalID(prefix, externalIDs)
 }
 
+func GetQuattroCampaignSegmentID(marketCode string, externalIDs []string) string {
+	prefix := formatQuattroKey(marketCode, quattroCampaignSegmentPrefix, "")
+	return parseExternalID(prefix, externalIDs)
+}
+
 func GetLegacySiteCode(externalIDs []string) string {
 	return getLegacyIOEntityNumericID(externalIDs, "site")
 }

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -146,6 +146,14 @@ func Test_GetQuattroCampaignID(t *testing.T) {
 	}
 }
 
+func Test_GetQuattroCampaignSegmentID(t *testing.T) {
+	extIds := []string{"quattro_CHI:campaignSegment:1234", "io:booking:2600", "io:display:5678"}
+	id := GetQuattroCampaignSegmentID("CHI", extIds)
+	if id != "1234" {
+		t.Errorf("expected 1234 got %s", id)
+	}
+}
+
 func Test_GetCustomerOrder(t *testing.T) {
 	extIds := []string{"customer:order:1234", "io:booking:2600", "io:display:5678"}
 	id := GetCustomerOrder(extIds)


### PR DESCRIPTION
this pr adds a helper to grab the `CampaignSegmentID` from a list of `ExternalIDs`.