### PR TITLE
Formatter for external agency reference code

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -6,19 +6,20 @@ import (
 )
 
 const (
-	extCustomerOrderPrefix     = "customer:order:"
-	geopathSegmentCodePrefix   = "geopath:segmentCode:"
-	geopathTargetProfilePrefix = "geopath:targetProfile:"
-	ioAccountIdPrefix          = "io:account:"
-	ioBookingIDPrefix          = "io:booking:"
-	ioCustomerPrefix           = "io:customer:"
-	ioEmployeeeNumberPrefix    = "io:employeeNumber:"
-	ioMarketPrefix             = "io:market:"
-	ioOrderIDPrefix            = "io:order:"
-	ioOrderNumberPrefix        = "io:orderNumber:"
-	ioOrderLinePrefix          = "io:orderLine:"
-	ioOrderLineTypePrefix      = "io:orderLineType:"
-	ioOrderMarketIDPrefix      = "io:orderMarket:"
+	extAgencyReferenceNumberPrefix = "agency:code:"
+	extCustomerOrderPrefix         = "customer:order:"
+	geopathSegmentCodePrefix       = "geopath:segmentCode:"
+	geopathTargetProfilePrefix     = "geopath:targetProfile:"
+	ioAccountIdPrefix              = "io:account:"
+	ioBookingIDPrefix              = "io:booking:"
+	ioCustomerPrefix               = "io:customer:"
+	ioEmployeeeNumberPrefix        = "io:employeeNumber:"
+	ioMarketPrefix                 = "io:market:"
+	ioOrderIDPrefix                = "io:order:"
+	ioOrderNumberPrefix            = "io:orderNumber:"
+	ioOrderLinePrefix              = "io:orderLine:"
+	ioOrderLineTypePrefix          = "io:orderLineType:"
+	ioOrderMarketIDPrefix          = "io:orderMarket:"
 
 	quattroDbPrefix              = "quattro_"
 	quattroCampaignPrefix        = ":campaign:"
@@ -41,6 +42,11 @@ func FormatIOCustomer(id interface{}) string {
 func FormatCustomerOrder(code interface{}) string {
 	return format(extCustomerOrderPrefix, fmt.Sprint(code))
 }
+
+func FormatExternalAgencyReferenceNumber(code interface{}) string {
+	return format(extAgencyReferenceNumberPrefix, fmt.Sprint(code))
+}
+
 func FormatGeopathSegmentCode(code interface{}) string {
 	return format(geopathSegmentCodePrefix, fmt.Sprint(code))
 }

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -161,3 +161,11 @@ func Test_GetCustomerOrder(t *testing.T) {
 		t.Errorf("expected 1234 got %s", id)
 	}
 }
+
+func Test_FormatExternalAgencyReferenceNumber(t *testing.T) {
+	testCode := "1234"
+	id := FormatExternalAgencyReferenceNumber(testCode)
+	if id != "agency:code:1234" {
+		t.Errorf("expected agency:code:1234 got %s", id)
+	}
+}


### PR DESCRIPTION
https://clearchanneloutdoor.atlassian.net/browse/PLAN-1274

adds a formatter for `agency:code:asdf1234` externalIDs