### PR TITLE
Revert "lowercase quattro's digitalbooking format"

### DIFF
--- a/externalIDs.go
+++ b/externalIDs.go
@@ -6,39 +6,38 @@ import (
 )
 
 const (
-	extCustomerOrderPrefix         = "customer:order:"
-	geopathSegmentCodePrefix       = "geopath:segmentCode:"
-	geopathTargetProfilePrefix     = "geopath:targetProfile:"
-	ioAccountIdPrefix              = "io:account:"
-	ioBookingIDPrefix              = "io:booking:"
-	ioCreativePrefix               = "io:creative:"
-	ioCustomerPrefix               = "io:customer:"
-	ioDocumentPrefix               = "io:document:"
-	ioDisplayPrefix                = "io:display:"
-	ioEmployeePrefix               = "io:employee:"
-	ioEmployeeNumberPrefix         = "io:employeeNumber:"
-	ioGroupBookingPrefix           = "io:groupBooking:"
-	ioOrderLineTypePrefix          = "io:lineType:"
-	ioMarketPrefix                 = "io:market:"
-	ioNetworkPrefix                = "io:network:"
-	ioNetworkCodePrefix            = "io:networkCode:"
-	ioOrderIDPrefix                = "io:order:"
-	ioOrderLinePrefix              = "io:orderLine:"
-	ioOrderMarketIDPrefix          = "io:orderMarket:"
-	ioOrderNumberPrefix            = "io:orderNumber:"
-	ioProductMapIDPrefix           = "io:productMap:"
-	quattroDbPrefix                = "quattro_"
-	quattroBookingPrefix           = ":booking:"
-	quattroCampaignPrefix          = ":campaign:"
-	quattroCampaignDetailPrefix    = ":campaignDetail:"
-	quattroCampaignSegmentPrefix   = ":campaignSegment:"
-	quattroDigitalBookingPrefix    = ":digitalbooking:"
-	oldQuattroDigitalBookingPrefix = ":digitalBooking:"
-	quattroDisplayID               = ":display:"
-	quattroNetworkID               = ":network:"
-	spotChartDisplayPrefix         = "spotchart:display:"
-	spotChartScenePrefix           = "spotchart:scene:"
-	spotChartSegmentPrefix         = "spotchart:segment:"
+	extCustomerOrderPrefix       = "customer:order:"
+	geopathSegmentCodePrefix     = "geopath:segmentCode:"
+	geopathTargetProfilePrefix   = "geopath:targetProfile:"
+	ioAccountIdPrefix            = "io:account:"
+	ioBookingIDPrefix            = "io:booking:"
+	ioCreativePrefix             = "io:creative:"
+	ioCustomerPrefix             = "io:customer:"
+	ioDocumentPrefix             = "io:document:"
+	ioDisplayPrefix              = "io:display:"
+	ioEmployeePrefix             = "io:employee:"
+	ioEmployeeNumberPrefix       = "io:employeeNumber:"
+	ioGroupBookingPrefix         = "io:groupBooking:"
+	ioOrderLineTypePrefix        = "io:lineType:"
+	ioMarketPrefix               = "io:market:"
+	ioNetworkPrefix              = "io:network:"
+	ioNetworkCodePrefix          = "io:networkCode:"
+	ioOrderIDPrefix              = "io:order:"
+	ioOrderLinePrefix            = "io:orderLine:"
+	ioOrderMarketIDPrefix        = "io:orderMarket:"
+	ioOrderNumberPrefix          = "io:orderNumber:"
+	ioProductMapIDPrefix         = "io:productMap:"
+	quattroDbPrefix              = "quattro_"
+	quattroBookingPrefix         = ":booking:"
+	quattroCampaignPrefix        = ":campaign:"
+	quattroCampaignDetailPrefix  = ":campaignDetail:"
+	quattroCampaignSegmentPrefix = ":campaignSegment:"
+	quattroDigitalBookingPrefix  = ":digitalBooking:"
+	quattroDisplayID             = ":display:"
+	quattroNetworkID             = ":network:"
+	spotChartDisplayPrefix       = "spotchart:display:"
+	spotChartScenePrefix         = "spotchart:scene:"
+	spotChartSegmentPrefix       = "spotchart:segment:"
 )
 
 /* FORMATTERS */
@@ -270,12 +269,6 @@ func GetQuattroCampaignSegmentID(marketCode string, externalIDs []string) string
 
 func GetQuattroDigitalBookingID(sourceDbCode string, externalIDs []string) string {
 	prefix := formatQuattroKey(sourceDbCode, quattroDigitalBookingPrefix, "")
-	extId := parseExternalID(prefix, externalIDs)
-	if extId != "" {
-		return extId
-	}
-
-	prefix = formatQuattroKey(sourceDbCode, oldQuattroDigitalBookingPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -176,7 +176,7 @@ func Test_QuattroFormatters(t *testing.T) {
 			quattroDb:      "chicago",
 			id:             "1234",
 			fn:             FormatQuattroDigitalBookingID,
-			expectedResult: "quattro_chicago:digitalbooking:1234",
+			expectedResult: "quattro_chicago:digitalBooking:1234",
 		},
 		{
 			name:           "display",
@@ -420,13 +420,6 @@ func Test_QuattroGetters(t *testing.T) {
 		},
 		{
 			name:           "digital booking",
-			quattroDb:      "chicago",
-			externalIDs:    []string{"quattro_chicago:digitalbooking:1234"},
-			fn:             GetQuattroDigitalBookingID,
-			expectedResult: "1234",
-		},
-		{
-			name:           "old format digital booking",
 			quattroDb:      "chicago",
 			externalIDs:    []string{"quattro_chicago:digitalBooking:1234"},
 			fn:             GetQuattroDigitalBookingID,


### PR DESCRIPTION
moving forward with `quattro_{market}:digitalBooking:{id}`