### PR TITLE
updated signatures in quattro methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes in external-ids will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.1.17] - 2025-07-14
+
+-- [IOC-1227] Update quattro related method signature names to reflect what is being passed in and used
+-- added changelog

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -33,7 +33,7 @@ const (
 	ioProductMapIDPrefix   = "io:productMap:"
 
 	// Quattro Formats
-	quattroDbPrefix                 = "quattro_"
+	quattroDbLongformPrefix         = "quattro_"
 	quattroBookingPrefix            = ":booking:"
 	quattroCampaignPrefix           = ":campaign:"
 	quattroDetailPrefix             = ":detail:"
@@ -153,36 +153,36 @@ func FormatIOProductMap(id interface{}) string {
 }
 
 // Quattro Formatters
-func FormatQuattroCampaign(marketCode string, campaignId interface{}) string {
-	return formatQuattroKey(marketCode, quattroCampaignPrefix, fmt.Sprint(campaignId))
+func FormatQuattroCampaign(dbLongForm string, campaignId interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroCampaignPrefix, fmt.Sprint(campaignId))
 }
 
-func FormatQuattroCampaignSegment(marketCode string, segmentId interface{}) string {
-	return formatQuattroKey(marketCode, quattroSegmentPrefix, fmt.Sprint(segmentId))
+func FormatQuattroCampaignSegment(dbLongForm string, segmentId interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroSegmentPrefix, fmt.Sprint(segmentId))
 }
 
-func FormatQuattroCampaignDetail(marketCode string, detailId interface{}) string {
-	return formatQuattroKey(marketCode, quattroDetailPrefix, fmt.Sprint(detailId))
+func FormatQuattroCampaignDetail(dbLongForm string, detailId interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroDetailPrefix, fmt.Sprint(detailId))
 }
 
-func FormatQuattroBookingID(sourceDbCode string, bookingID interface{}) string {
-	return formatQuattroKey(sourceDbCode, quattroBookingPrefix, fmt.Sprint(bookingID))
+func FormatQuattroBookingID(dbLongForm string, bookingID interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroBookingPrefix, fmt.Sprint(bookingID))
 }
 
-func FormatQuattroDigitalBookingID(sourceDbCode string, bookingID interface{}) string {
-	return formatQuattroKey(sourceDbCode, quattroDigitalBookingPrefix, fmt.Sprint(bookingID))
+func FormatQuattroDigitalBookingID(dbLongForm string, bookingID interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroDigitalBookingPrefix, fmt.Sprint(bookingID))
 }
 
-func FormatQuattroDisplayID(sourceDbCode string, panelID interface{}) string {
-	return formatQuattroKey(sourceDbCode, quattroDisplayID, fmt.Sprint(panelID))
+func FormatQuattroDisplayID(dbLongForm string, panelID interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroDisplayID, fmt.Sprint(panelID))
 }
 
-func FormatQuattroMarketID(sourceDbCode string, marketID interface{}) string {
-	return formatQuattroKey(sourceDbCode, quattroMarketID, fmt.Sprint(marketID))
+func FormatQuattroMarketID(dbLongForm string, marketID interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroMarketID, fmt.Sprint(marketID))
 }
 
-func FormatQuattroNetworkID(sourceDbCode string, digitalProductID interface{}) string {
-	return formatQuattroKey(sourceDbCode, quattroNetworkID, fmt.Sprint(digitalProductID))
+func FormatQuattroNetworkID(dbLongForm string, digitalProductID interface{}) string {
+	return formatQuattroKey(dbLongForm, quattroNetworkID, fmt.Sprint(digitalProductID))
 }
 
 // SF Formatters
@@ -335,44 +335,44 @@ func GetOrderNumber(externalIDs []string) string {
 
 // Quattro Getters
 
-func GetQuattroBookingID(sourceDbCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(sourceDbCode, quattroBookingPrefix, "")
+func GetQuattroBookingID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroBookingPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroCampaignID(marketCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(marketCode, quattroCampaignPrefix, "")
+func GetQuattroCampaignID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroCampaignPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroCampaignSegmentID(marketCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(marketCode, quattroSegmentPrefix, "")
+func GetQuattroCampaignSegmentID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroSegmentPrefix, "")
 	extId := parseExternalID(prefix, externalIDs)
 	if extId != "" {
 		return extId
 	}
 
-	oldPrefix := formatQuattroKey(marketCode, oldQuattroCampaignSegmentPrefix, "")
+	oldPrefix := formatQuattroKey(dbLongForm, oldQuattroCampaignSegmentPrefix, "")
 	return parseExternalID(oldPrefix, externalIDs)
 }
 
-func GetQuattroDigitalBookingID(sourceDbCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(sourceDbCode, quattroDigitalBookingPrefix, "")
+func GetQuattroDigitalBookingID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroDigitalBookingPrefix, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroDisplayID(sourceDbCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(sourceDbCode, quattroDisplayID, "")
+func GetQuattroDisplayID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroDisplayID, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroMarketID(sourceDbCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(sourceDbCode, quattroMarketID, "")
+func GetQuattroMarketID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroMarketID, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
-func GetQuattroNetworkID(sourceDbCode string, externalIDs []string) string {
-	prefix := formatQuattroKey(sourceDbCode, quattroNetworkID, "")
+func GetQuattroNetworkID(dbLongForm string, externalIDs []string) string {
+	prefix := formatQuattroKey(dbLongForm, quattroNetworkID, "")
 	return parseExternalID(prefix, externalIDs)
 }
 
@@ -436,8 +436,8 @@ func GetSpotChartSegment(externalIDs []string) string {
 
 /* helpers */
 
-func formatQuattroKey(marketCode string, entity string, id string) string {
-	quattroKey := format(quattroDbPrefix, marketCode)
+func formatQuattroKey(dbLongForm string, entity string, id string) string {
+	quattroKey := format(quattroDbLongformPrefix, dbLongForm)
 	prefix := format(quattroKey, entity)
 	return format(prefix, id)
 }

--- a/externalIDs.go
+++ b/externalIDs.go
@@ -33,7 +33,7 @@ const (
 	ioProductMapIDPrefix   = "io:productMap:"
 
 	// Quattro Formats
-	quattroDbLongformPrefix         = "quattro_"
+	quattroDbLongFormPrefix         = "quattro_"
 	quattroBookingPrefix            = ":booking:"
 	quattroCampaignPrefix           = ":campaign:"
 	quattroDetailPrefix             = ":detail:"
@@ -437,7 +437,7 @@ func GetSpotChartSegment(externalIDs []string) string {
 /* helpers */
 
 func formatQuattroKey(dbLongForm string, entity string, id string) string {
-	quattroKey := format(quattroDbLongformPrefix, dbLongForm)
+	quattroKey := format(quattroDbLongFormPrefix, dbLongForm)
 	prefix := format(quattroKey, entity)
 	return format(prefix, id)
 }

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -492,7 +492,7 @@ func Test_QuattroGetters(t *testing.T) {
 		},
 		{
 			name:           "campaign, wrong market",
-			dbLongForm:     "el_paso",
+			dbLongForm:     "quattro_el_paso",
 			externalIDs:    []string{"quattro_chicago:campaign:1234"},
 			fn:             GetQuattroCampaignID,
 			expectedResult: "",
@@ -514,7 +514,7 @@ func Test_QuattroGetters(t *testing.T) {
 		{
 			name:           "campaign segment, wrong market",
 			dbLongForm:     "quattro_chicago",
-			externalIDs:    []string{"el_paso:campaignSegment:1234"},
+			externalIDs:    []string{"quattro_el_paso:campaignSegment:1234"},
 			fn:             GetQuattroCampaignSegmentID,
 			expectedResult: "",
 		},
@@ -528,7 +528,7 @@ func Test_QuattroGetters(t *testing.T) {
 		{
 			name:           "digital booking, wrong market",
 			dbLongForm:     "quattro_chicago",
-			externalIDs:    []string{"el_paso:digitalBooking:1234"},
+			externalIDs:    []string{"quattro_el_paso:digitalBooking:1234"},
 			fn:             GetQuattroDigitalBookingID,
 			expectedResult: "",
 		},
@@ -542,7 +542,7 @@ func Test_QuattroGetters(t *testing.T) {
 		{
 			name:           "display, wrong market",
 			dbLongForm:     "quattro_chicago",
-			externalIDs:    []string{"el_paso:display:1234"},
+			externalIDs:    []string{"quattro_el_paso:display:1234"},
 			fn:             GetQuattroDisplayID,
 			expectedResult: "",
 		},
@@ -562,7 +562,7 @@ func Test_QuattroGetters(t *testing.T) {
 		},
 		{
 			name:           "network, wrong market",
-			dbLongForm:     "el_paso",
+			dbLongForm:     "quattro_el_paso",
 			externalIDs:    []string{"quattro_chicago:network:1234"},
 			fn:             GetQuattroNetworkID,
 			expectedResult: "",

--- a/externalIDs_test.go
+++ b/externalIDs_test.go
@@ -136,7 +136,7 @@ func Test_IOFormatters(t *testing.T) {
 func Test_QuattroFormatters(t *testing.T) {
 	type testRun struct {
 		name           string
-		quattroDb      string
+		dbLongForm     string
 		id             string
 		fn             func(string, interface{}) string
 		expectedResult string
@@ -145,56 +145,56 @@ func Test_QuattroFormatters(t *testing.T) {
 	runs := []testRun{
 		{
 			name:           "booking",
-			quattroDb:      "quattro_chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroBookingID,
 			expectedResult: "quattro_chicago:booking:1234",
 		},
 		{
 			name:           "campaign",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroCampaign,
 			expectedResult: "quattro_chicago:campaign:1234",
 		},
 		{
 			name:           "campaign detail",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroCampaignDetail,
 			expectedResult: "quattro_chicago:detail:1234",
 		},
 		{
 			name:           "campaign segment",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroCampaignSegment,
 			expectedResult: "quattro_chicago:segment:1234",
 		},
 		{
 			name:           "digital booking",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroDigitalBookingID,
 			expectedResult: "quattro_chicago:digitalBooking:1234",
 		},
 		{
 			name:           "display",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroDisplayID,
 			expectedResult: "quattro_chicago:display:1234",
 		},
 		{
 			name:           "market",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "*",
 			fn:             FormatQuattroMarketID,
 			expectedResult: "quattro_chicago:market:*",
 		},
 		{
 			name:           "network",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			id:             "1234",
 			fn:             FormatQuattroNetworkID,
 			expectedResult: "quattro_chicago:network:1234",
@@ -203,7 +203,7 @@ func Test_QuattroFormatters(t *testing.T) {
 
 	for _, test := range runs {
 		t.Run(test.name, func(t *testing.T) {
-			formattedId := test.fn(test.quattroDb, test.id)
+			formattedId := test.fn(test.dbLongForm, test.id)
 			assert.Equal(t, test.expectedResult, formattedId)
 		})
 	}
@@ -462,7 +462,7 @@ func Test_IOGetters(t *testing.T) {
 func Test_QuattroGetters(t *testing.T) {
 	type testRun struct {
 		name           string
-		quattroDb      string
+		dbLongForm     string
 		externalIDs    []string
 		fn             func(string, []string) string
 		expectedResult string
@@ -471,98 +471,98 @@ func Test_QuattroGetters(t *testing.T) {
 	runs := []testRun{
 		{
 			name:           "booking",
-			quattroDb:      "quattro_chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:booking:1234"},
 			fn:             GetQuattroBookingID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "booking, wrong market",
-			quattroDb:      "quattro_el_paso",
+			dbLongForm:     "quattro_el_paso",
 			externalIDs:    []string{"quattro_chicago:booking:1234"},
 			fn:             GetQuattroBookingID,
 			expectedResult: "",
 		},
 		{
 			name:           "campaign",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:campaign:1234"},
 			fn:             GetQuattroCampaignID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "campaign, wrong market",
-			quattroDb:      "el_paso",
+			dbLongForm:     "el_paso",
 			externalIDs:    []string{"quattro_chicago:campaign:1234"},
 			fn:             GetQuattroCampaignID,
 			expectedResult: "",
 		},
 		{
 			name:           "campaign segment",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:segment:1234"},
 			fn:             GetQuattroCampaignSegmentID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "old campaign segment format",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:campaignSegment:1234"},
 			fn:             GetQuattroCampaignSegmentID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "campaign segment, wrong market",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"el_paso:campaignSegment:1234"},
 			fn:             GetQuattroCampaignSegmentID,
 			expectedResult: "",
 		},
 		{
 			name:           "digital booking",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:digitalBooking:1234"},
 			fn:             GetQuattroDigitalBookingID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "digital booking, wrong market",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"el_paso:digitalBooking:1234"},
 			fn:             GetQuattroDigitalBookingID,
 			expectedResult: "",
 		},
 		{
 			name:           "display",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:display:1234"},
 			fn:             GetQuattroDisplayID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "display, wrong market",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"el_paso:display:1234"},
 			fn:             GetQuattroDisplayID,
 			expectedResult: "",
 		},
 		{
 			name:           "market",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:market:1234"},
 			fn:             GetQuattroMarketID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "network",
-			quattroDb:      "chicago",
+			dbLongForm:     "quattro_chicago",
 			externalIDs:    []string{"quattro_chicago:network:1234"},
 			fn:             GetQuattroNetworkID,
 			expectedResult: "1234",
 		},
 		{
 			name:           "network, wrong market",
-			quattroDb:      "el_paso",
+			dbLongForm:     "el_paso",
 			externalIDs:    []string{"quattro_chicago:network:1234"},
 			fn:             GetQuattroNetworkID,
 			expectedResult: "",
@@ -571,7 +571,7 @@ func Test_QuattroGetters(t *testing.T) {
 
 	for _, test := range runs {
 		t.Run(test.name, func(t *testing.T) {
-			extId := test.fn(test.quattroDb, test.externalIDs)
+			extId := test.fn(test.dbLongForm, test.externalIDs)
 			assert.Equal(t, test.expectedResult, extId)
 		})
 	}


### PR DESCRIPTION
- removing confusion when passing in dbLongForm from booking-sync-svc to a method that requests either sourceDb or marketCode

- added changelog